### PR TITLE
Problem: in 2nd Ex. students may sync-call push

### DIFF
--- a/src/bin/hypull.rs
+++ b/src/bin/hypull.rs
@@ -6,13 +6,17 @@ use std::{
 };
 
 fn main() {
-    let mut pipe = HyperPipe::new(Path::new("./test-pipe-data")).unwrap();
+    let mut pipe = HyperPipe::new(Path::new("./test-pipe-data"), 0).unwrap();
 
     eprintln!("Press Ctrl-C to exit this pull loop!");
     loop {
         match pipe.pull() {
             Some(data) => io::stdout().write_all(data.as_slice()).unwrap(),
-            None => thread::sleep_ms(200), //thread::yield_now(),
+            None => {
+                // Make a duration for 200ms
+                let dur = std::time::Duration::from_millis(200);
+                thread::sleep(dur) //thread::yield_now(),
+            }
         }
     }
 }

--- a/src/bin/hypush.rs
+++ b/src/bin/hypush.rs
@@ -2,11 +2,10 @@ use hyperpipe::HyperPipe;
 use std::{
     io::{self, Read},
     path::Path,
-    time::Duration,
 };
 
 fn main() {
-    let mut pipe = HyperPipe::new(Path::new("./test-pipe-data")).unwrap();
+    let mut pipe = HyperPipe::new(Path::new("./test-pipe-data"), 0).unwrap();
 
     let mut input = vec![];
     io::stdin().read_to_end(&mut input).unwrap();


### PR DESCRIPTION
This is a problem because then pending branch will never be executed, but the output will be correct anyway.

Solution:
 - Provide students with a facility to add an artificial lag, which will be applied both on pull and push.
 - This makes it quite a bit more obvious that push is happening in a sync way.

Probably, pull lag is unnecessary, but whatever :3